### PR TITLE
Adding the aws cli (via python) to the ol-infrastructure packer builder.

### DIFF
--- a/Dockerfile.mitol_build
+++ b/Dockerfile.mitol_build
@@ -9,6 +9,7 @@ RUN apt-get update -yqq && apt-get install -yqq curl openssh-client unzip && \
     curl "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" -o packer.zip && \
     unzip packer.zip -d /bin/ && \
     rm -f packer.zip &&\
+    pip install awscli &&\
     packer plugins install github.com/hashicorp/amazon
 COPY bin/* /opt/resource/
 COPY lib/* /opt/resource/lib/


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/issues/1979

# Description (What does it do?)
This will add the 'aws-cli' to the container that does our packer builds. It will allow us to invoke aws-cli calls via the shell-local provisioner after the main part of a packer build is completed. 

# How can this be tested?
```
docker build --platform=linux/amd64 -f Dockerfile.mitol_build . 
docker run --platform=linux/amd64 <image hash> bash
# confirm scp is installed
scp
# confirm aws is installed
aws --version
```
